### PR TITLE
Fix parsing modifiers with context of block/elem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+package-lock.json
 
 # Created by https://www.gitignore.io/api/node
 

--- a/README.md
+++ b/README.md
@@ -77,13 +77,10 @@ Context allows to extract portion of entities.
 ```js
 var enties = parse('m:theme=normal', { block: 'button' });
 
-// → [ { block: 'button', mod: { name: 'theme' } },
+// → [ { block: 'button' },
+//     { block: 'button', mod: { name: 'theme' } },
 //     { block: 'button', mod: { name: 'theme', val: 'normal' } } ]
 ```
-
-Note that, using context exludes `{ block: 'button'}` from result.
-
-So `parse('m:theme=normal', { block: 'button' })` is not same as `parse('b:button m:theme=normal')`
 
 ### stringify
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function parse(importString, ctx) {
             if(!main.block) {
                 main.block = ctx.block;
                 main.elem || ctx.elem && (main.elem = ctx.elem);
+                acc.push(main);
             }
 
             if(type === 'm') {

--- a/test/parse.js
+++ b/test/parse.js
@@ -61,12 +61,14 @@ describe('block', () => {
         describe('context is block', () => {
             it('should extract blockMod', () => {
                 expect(p('m:autoclosable', { block : 'popup' })).to.eql([
+                    { block : 'popup' },
                     { block : 'popup', mod : { name : 'autoclosable' } }
                 ]);
             });
 
             it('should extract block with modifier', () => {
                 expect(p('m:autoclosable=yes', { block : 'popup' })).to.eql([
+                    { block : 'popup' },
                     { block : 'popup', mod : { name : 'autoclosable' } },
                     { block : 'popup', mod : { name : 'autoclosable', val : 'yes' } }
                 ]);
@@ -74,6 +76,7 @@ describe('block', () => {
 
             it('should extract blockMod with several values', () => {
                 expect(p('m:theme=normal|action', { block : 'popup' })).to.eql([
+                    { block : 'popup' },
                     { block : 'popup', mod : { name : 'theme' } },
                     { block : 'popup', mod : { name : 'theme', val : 'normal' } },
                     { block : 'popup', mod : { name : 'theme', val : 'action' } }
@@ -82,6 +85,7 @@ describe('block', () => {
 
             it('should extract blockMod with several modifiers', () => {
                 expect(p('m:theme m:autoclosable', { block : 'popup' })).to.eql([
+                    { block : 'popup' },
                     { block : 'popup', mod : { name : 'theme' } },
                     { block : 'popup', mod : { name : 'autoclosable' } }
                 ]);
@@ -89,6 +93,7 @@ describe('block', () => {
 
             it('should extract blockMods with several modifiers and several values', () => {
                 expect(p('m:theme=normal|action m:autoclosable=yes', { block : 'popup' })).to.eql([
+                    { block : 'popup' },
                     { block : 'popup', mod : { name : 'theme' } },
                     { block : 'popup', mod : { name : 'theme', val : 'normal' } },
                     { block : 'popup', mod : { name : 'theme', val : 'action' } },
@@ -314,12 +319,14 @@ describe('elem', () => {
             describe('context is elem', () => {
                 it('should extract elem with simple modifier', () => {
                     expect(p('m:pseudo', { block : 'button2', elem : 'text' })).to.eql([
+                        { block : 'button2', elem : 'text' },
                         { block : 'button2', elem : 'text', mod : { name : 'pseudo' } }
                     ]);
                 });
 
                 it('should extract elem with modifier', () => {
                     expect(p('m:pseudo=yes', { block : 'button2', elem : 'text' })).to.eql([
+                        { block : 'button2', elem : 'text' },
                         { block : 'button2', elem : 'text', mod : { name : 'pseudo' } },
                         { block : 'button2', elem : 'text', mod : { name : 'pseudo', val : 'yes' } }
                     ]);
@@ -327,6 +334,7 @@ describe('elem', () => {
 
                 it('should extract elem with modifier and several values', () => {
                     expect(p('m:theme=normal|action', { block : 'button2', elem : 'text' })).to.eql([
+                        { block : 'button2', elem : 'text' },
                         { block : 'button2', elem : 'text', mod : { name : 'theme' } },
                         { block : 'button2', elem : 'text', mod : { name : 'theme', val : 'normal' } },
                         { block : 'button2', elem : 'text', mod : { name : 'theme', val : 'action' } }
@@ -335,6 +343,7 @@ describe('elem', () => {
 
                 it('should extract elem with several modifiers', () => {
                     expect(p('m:theme m:autoclosable', { block : 'popup', elem : 'tail' })).to.eql([
+                        { block : 'popup', elem : 'tail' },
                         { block : 'popup', elem : 'tail', mod : { name : 'theme' } },
                         { block : 'popup', elem : 'tail', mod : { name : 'autoclosable' } }
                     ]);
@@ -344,6 +353,7 @@ describe('elem', () => {
                     expect(
                         p('m:theme=normal|action m:autoclosable=yes', { block : 'popup', elem : 'tail' })
                     ).to.eql([
+                        { block : 'popup', elem : 'tail' },
                         { block : 'popup', elem : 'tail', mod : { name : 'theme' } },
                         { block : 'popup', elem : 'tail', mod : { name : 'theme', val : 'normal' } },
                         { block : 'popup', elem : 'tail', mod : { name : 'theme', val : 'action' } },
@@ -409,12 +419,14 @@ describe('elem', () => {
             describe('context is current elem', () => {
                 it('should extract elem with simple modifier', () => {
                     expect(p('e:text m:pseudo', { block : 'button2', elem : 'text' })).to.eql([
+                        { block : 'button2', elem : 'text' },
                         { block : 'button2', elem : 'text', mod : { name : 'pseudo' } }
                     ]);
                 });
 
                 it('should extract elem with modifier', () => {
                     expect(p('e:text m:pseudo=yes', { block : 'button2', elem : 'text' })).to.eql([
+                        { block : 'button2', elem : 'text' },
                         { block : 'button2', elem : 'text', mod : { name : 'pseudo' } },
                         { block : 'button2', elem : 'text', mod : { name : 'pseudo', val : 'yes' } }
                     ]);
@@ -422,6 +434,7 @@ describe('elem', () => {
 
                 it('should extract elem with modifier and several values', () => {
                     expect(p('e:text m:theme=normal|action', { block : 'button2', elem : 'text' })).to.eql([
+                        { block : 'button2', elem : 'text' },
                         { block : 'button2', elem : 'text', mod : { name : 'theme' } },
                         { block : 'button2', elem : 'text', mod : { name : 'theme', val : 'normal' } },
                         { block : 'button2', elem : 'text', mod : { name : 'theme', val : 'action' } }
@@ -430,6 +443,7 @@ describe('elem', () => {
 
                 it('should extract elem with several modifiers', () => {
                     expect(p('e:tail m:theme m:autoclosable', { block : 'popup', elem : 'tail' })).to.eql([
+                        { block : 'popup', elem : 'tail' },
                         { block : 'popup', elem : 'tail', mod : { name : 'theme' } },
                         { block : 'popup', elem : 'tail', mod : { name : 'autoclosable' } }
                     ]);
@@ -439,6 +453,7 @@ describe('elem', () => {
                     expect(
                         p('e:tail m:theme=normal|action m:autoclosable=yes', { block : 'popup', elem : 'tail' })
                     ).to.eql([
+                        { block : 'popup', elem : 'tail' },
                         { block : 'popup', elem : 'tail', mod : { name : 'theme' } },
                         { block : 'popup', elem : 'tail', mod : { name : 'theme', val : 'normal' } },
                         { block : 'popup', elem : 'tail', mod : { name : 'theme', val : 'action' } },


### PR DESCRIPTION
Previous decision was wrong we actually need to extract main entity
Check this issue: https://github.com/bem/webpack-bem-loader/issues/64
Natural dependencies were broken